### PR TITLE
Add Support for Custom Log Handlers

### DIFF
--- a/examples/custom_handler.zig
+++ b/examples/custom_handler.zig
@@ -1,0 +1,133 @@
+const std = @import("std");
+const nexlog = @import("nexlog");
+const types = nexlog.core.types;
+const handlers = nexlog.output.handler;
+const Logger = nexlog.Logger;
+// Configuration for the custom handler
+pub const CustomConfig = struct {
+    min_level: types.LogLevel = .debug,
+    prefix: []const u8 = "CUSTOM",
+    buffer_size: usize = 4096,
+};
+
+// Custom handler that writes to a memory buffer
+pub const CustomHandler = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    config: CustomConfig,
+    messages: std.ArrayList([]const u8),
+
+    pub fn init(allocator: std.mem.Allocator, config: CustomConfig) !*Self {
+        const handler = try allocator.create(Self);
+        handler.* = .{
+            .allocator = allocator,
+            .config = config,
+            .messages = std.ArrayList([]const u8).init(allocator),
+        };
+        return handler;
+    }
+
+    pub fn deinit(self: *Self) void {
+        // Free all stored messages
+        for (self.messages.items) |msg| {
+            self.allocator.free(msg);
+        }
+        self.messages.deinit();
+        self.allocator.destroy(self);
+    }
+
+    pub fn log(
+        self: *Self,
+        level: types.LogLevel,
+        message: []const u8,
+        metadata: ?types.LogMetadata,
+    ) !void {
+        if (@intFromEnum(level) < @intFromEnum(self.config.min_level)) {
+            return;
+        }
+
+        // Format the message with prefix and timestamp
+        const timestamp = if (metadata) |m| m.timestamp else std.time.timestamp();
+        const formatted = try std.fmt.allocPrint(
+            self.allocator,
+            "[{d}] [{s}] [{s}] {s}",
+            .{
+                timestamp,
+                self.config.prefix,
+                level.toString(),
+                message,
+            },
+        );
+
+        // Store the message
+        try self.messages.append(formatted);
+    }
+
+    pub fn flush(self: *Self) !void {
+        // Example: Print all stored messages
+        for (self.messages.items) |msg| {
+            std.debug.print("{s}\n", .{msg});
+        }
+    }
+
+    // Get all stored messages
+    pub fn getMessages(self: *Self) []const []const u8 {
+        return self.messages.items;
+    }
+
+    // Clear all stored messages
+    pub fn clearMessages(self: *Self) void {
+        for (self.messages.items) |msg| {
+            self.allocator.free(msg);
+        }
+        self.messages.clearRetainingCapacity();
+    }
+
+    /// Convert to generic LogHandler interface
+    pub fn toLogHandler(self: *Self) handlers.LogHandler {
+        return handlers.LogHandler.init(
+            self,
+            CustomHandler.log,
+            CustomHandler.flush,
+            CustomHandler.deinit,
+        );
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    // Create logger instance
+    const logger = try Logger.init(allocator, .{});
+    defer logger.deinit();
+
+    // Create custom handler with configuration
+    var custom_handler = try CustomHandler.init(allocator, .{
+        .min_level = .info,
+        .prefix = "MY_APP",
+    });
+
+    // Add the custom handler to the logger
+    try logger.addHandler(custom_handler.toLogHandler());
+
+    // Log some messages
+    try logger.log(.info, "Application started", .{}, null);
+    try logger.log(.warn, "Low memory warning", .{}, null);
+    try logger.log(.err, "Failed to connect", .{}, null);
+
+    // Access the stored messages
+    const messages = custom_handler.getMessages();
+    std.debug.print("\nStored messages:\n", .{});
+    for (messages) |msg| {
+        std.debug.print("{s}\n", .{msg});
+    }
+
+    // Clear stored messages
+    custom_handler.clearMessages();
+
+    // Flush all handlers
+    try logger.flush();
+}

--- a/examples/file_rotation.zig
+++ b/examples/file_rotation.zig
@@ -78,7 +78,7 @@ pub fn main() !void {
     try logger.log(.info, "Demonstration complete - check logs/test.log and logs/test.log.1-3", .{}, base_metadata);
 
     // List all log files
-    var dir = try std.fs.cwd().openDir("logs", .{});
+    var dir = try std.fs.cwd().openDir("logs", .{ .iterate = true });
     defer dir.close();
 
     var dir_iter = dir.iterate();

--- a/src/core/config.zig
+++ b/src/core/config.zig
@@ -2,6 +2,7 @@ const LogLevel = @import("types.zig").LogLevel;
 
 pub const LogConfig = struct {
     min_level: LogLevel = .info,
+    enable_console: bool = true,
     enable_colors: bool = true,
     enable_file_logging: bool = false,
     file_path: ?[]const u8 = null,

--- a/src/nexlog.zig
+++ b/src/nexlog.zig
@@ -20,6 +20,12 @@ pub const utils = struct {
     pub const pool = @import("utils/pool.zig");
 };
 
+pub const output = struct {
+    pub const console = @import("output/console.zig");
+    pub const file = @import("output/file.zig");
+    pub const handler = @import("output/handlers.zig");
+};
+
 // Re-export main types and functions
 pub const Logger = core.logger.Logger;
 pub const LogLevel = core.types.LogLevel;
@@ -52,7 +58,7 @@ pub const CategoryRule = analysis.patterns.CategoryRule;
 pub const VariableRule = analysis.patterns.VariableRule;
 
 // Re-export utility functionality
-pub const Buffer = utils.buffer.Buffer;
+pub const CircularBuffer = utils.buffer.CircularBuffer;
 pub const Pool = utils.pool.Pool;
 
 // Example test

--- a/src/output/handlers.zig
+++ b/src/output/handlers.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const types = @import("../core/types.zig");
+
+/// Interface that all log handlers must implement
+pub const LogHandler = struct {
+    /// Pointer to implementation of writeLog
+    writeLogFn: *const fn (
+        ctx: *anyopaque,
+        level: types.LogLevel,
+        message: []const u8,
+        metadata: ?types.LogMetadata,
+    ) anyerror!void,
+
+    /// Pointer to implementation of flush
+    flushFn: *const fn (ctx: *anyopaque) anyerror!void,
+
+    /// Pointer to implementation of deinit
+    deinitFn: *const fn (ctx: *anyopaque) void,
+
+    /// Context pointer to the actual handler instance
+    ctx: *anyopaque,
+
+    /// Create a LogHandler interface from a specific handler type
+    pub fn init(
+        pointer: anytype,
+        comptime writeLogFnT: fn (
+            ptr: @TypeOf(pointer),
+            level: types.LogLevel,
+            message: []const u8,
+            metadata: ?types.LogMetadata,
+        ) anyerror!void,
+        comptime flushFnT: fn (ptr: @TypeOf(pointer)) anyerror!void,
+        comptime deinitFnT: fn (ptr: @TypeOf(pointer)) void,
+    ) LogHandler {
+        const Ptr = @TypeOf(pointer);
+        const ptr_info = @typeInfo(Ptr);
+
+        std.debug.assert(ptr_info == .Pointer); // Must be a pointer
+        std.debug.assert(ptr_info.Pointer.size == .One); // Must be a single-item pointer
+
+        const GenericWriteLog = struct {
+            fn implementation(
+                ctx: *anyopaque,
+                level: types.LogLevel,
+                message: []const u8,
+                metadata: ?types.LogMetadata,
+            ) !void {
+                const self = @as(Ptr, @alignCast(@ptrCast(ctx)));
+                return writeLogFnT(self, level, message, metadata);
+            }
+        }.implementation;
+
+        const GenericFlush = struct {
+            fn implementation(ctx: *anyopaque) !void {
+                const self = @as(Ptr, @alignCast(@ptrCast(ctx)));
+                return flushFnT(self);
+            }
+        }.implementation;
+
+        const GenericDeinit = struct {
+            fn implementation(ctx: *anyopaque) void {
+                const self = @as(Ptr, @alignCast(@ptrCast(ctx)));
+                deinitFnT(self);
+            }
+        }.implementation;
+
+        return .{
+            .writeLogFn = GenericWriteLog,
+            .flushFn = GenericFlush,
+            .deinitFn = GenericDeinit,
+            .ctx = pointer,
+        };
+    }
+
+    /// Write a log message using this handler
+    pub fn writeLog(
+        self: LogHandler,
+        level: types.LogLevel,
+        message: []const u8,
+        metadata: ?types.LogMetadata,
+    ) !void {
+        return self.writeLogFn(self.ctx, level, message, metadata);
+    }
+
+    /// Flush any buffered output
+    pub fn flush(self: LogHandler) !void {
+        return self.flushFn(self.ctx);
+    }
+
+    /// Clean up the handler
+    pub fn deinit(self: LogHandler) void {
+        self.deinitFn(self.ctx);
+    }
+};


### PR DESCRIPTION
This PR introduces a new LogHandler interface that allows users to create their own custom handlers. This was motivated by user requests #10  for UI integration and other custom output types.

## Custom Handler Interface

```zig
pub const LogHandler = struct {
    writeLogFn: *const fn (ctx: *anyopaque, level: LogLevel, message: []const u8, metadata: ?LogMetadata) anyerror!void,
    flushFn: *const fn (ctx: *anyopaque) anyerror!void,
    deinitFn: *const fn (ctx: *anyopaque) void,
    ctx: *anyopaque,
};
```

## Example Usage

```zig
// Configuration for the custom handler
pub const CustomConfig = struct {
    min_level: types.LogLevel = .debug,
    prefix: []const u8 = "CUSTOM",
    buffer_size: usize = 4096,
};

// Custom handler that writes to a memory buffer
pub const CustomHandler = struct {
    const Self = @This();

    allocator: std.mem.Allocator,
    config: CustomConfig,
    messages: std.ArrayList([]const u8),

    pub fn init(allocator: std.mem.Allocator, config: CustomConfig) !*Self {
        const handler = try allocator.create(Self);
        handler.* = .{
            .allocator = allocator,
            .config = config,
            .messages = std.ArrayList([]const u8).init(allocator),
        };
        return handler;
    }

    pub fn deinit(self: *Self) void {
        // Free all stored messages
        for (self.messages.items) |msg| {
            self.allocator.free(msg);
        }
        self.messages.deinit();
        self.allocator.destroy(self);
    }

    pub fn log(
        self: *Self,
        level: types.LogLevel,
        message: []const u8,
        metadata: ?types.LogMetadata,
    ) !void {
        if (@intFromEnum(level) < @intFromEnum(self.config.min_level)) {
            return;
        }

        // Format the message with prefix and timestamp
        const timestamp = if (metadata) |m| m.timestamp else std.time.timestamp();
        const formatted = try std.fmt.allocPrint(
            self.allocator,
            "[{d}] [{s}] [{s}] {s}",
            .{
                timestamp,
                self.config.prefix,
                level.toString(),
                message,
            },
        );

        // Store the message
        try self.messages.append(formatted);
    }

    pub fn flush(self: *Self) !void {
        // Example: Print all stored messages
        for (self.messages.items) |msg| {
            std.debug.print("{s}\n", .{msg});
        }
    }

    // Get all stored messages
    pub fn getMessages(self: *Self) []const []const u8 {
        return self.messages.items;
    }

    // Clear all stored messages
    pub fn clearMessages(self: *Self) void {
        for (self.messages.items) |msg| {
            self.allocator.free(msg);
        }
        self.messages.clearRetainingCapacity();
    }

    /// Convert to generic LogHandler interface
    pub fn toLogHandler(self: *Self) handlers.LogHandler {
        return handlers.LogHandler.init(
            self,
            CustomHandler.log,
            CustomHandler.flush,
            CustomHandler.deinit,
        );
    }
};

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer _ = gpa.deinit();
    const allocator = gpa.allocator();

    // Create logger instance
    const logger = try Logger.init(allocator, .{});
    defer logger.deinit();

    // Create custom handler with configuration
    var custom_handler = try CustomHandler.init(allocator, .{
        .min_level = .info,
        .prefix = "MY_APP",
    });

    // Add the custom handler to the logger
    try logger.addHandler(custom_handler.toLogHandler());

    // Log some messages
    try logger.log(.info, "Application started", .{}, null);
    try logger.log(.warn, "Low memory warning", .{}, null);
    try logger.log(.err, "Failed to connect", .{}, null);

    // Access the stored messages
    const messages = custom_handler.getMessages();
    std.debug.print("\nStored messages:\n", .{});
    for (messages) |msg| {
        std.debug.print("{s}\n", .{msg});
    }

    // Clear stored messages
    custom_handler.clearMessages();

    // Flush all handlers
    try logger.flush();
}

```
## Breaking Changes
None. This is an additive change that maintains compatibility with existing code.

## Future Work
- Add more example handlers in documentation
- Create handler templates for common use cases
- Add handler filtering options