### PR TITLE
Refactor logging library and reimplement format.zig functionality

### DIFF
--- a/src/core/logger.zig
+++ b/src/core/logger.zig
@@ -106,7 +106,7 @@ pub const Logger = struct {
 
         // Send to all handlers
         for (self.handlers.items) |handler| {
-            handler.writeLog(level, message, metadata) catch |err| {
+            handler.writeLog(level, formatted_message, metadata) catch |err| {
                 std.debug.print("Handler error: {}\n", .{err});
             };
         }

--- a/src/nexlog.zig
+++ b/src/nexlog.zig
@@ -1,4 +1,3 @@
-// src/nexlog.zig
 const std = @import("std");
 
 pub const core = struct {
@@ -45,6 +44,10 @@ pub const isInitialized = core.init.isInitialized;
 pub const getDefaultLogger = core.init.getDefaultLogger;
 pub const LogBuilder = core.init.LogBuilder;
 
+// Re-export formatter types and functions
+pub const FormatConfig = utils.format.FormatConfig;
+pub const Formatter = utils.format.Formatter;
+
 // Re-export pattern analysis types and functions
 // pub const PatternType = core.types.PatternType;
 // pub const PatternVariable = core.types.PatternVariable;
@@ -82,4 +85,29 @@ test "basic log test" {
     defer log.deinit();
 
     try log.log(.err, "Test message", .{}, null);
+}
+
+// Test for formatter functionality
+test "formatter functionality test" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const format_config = FormatConfig{
+        .template = "[{timestamp}] [{level}] {message}",
+        .timestamp_format = .unix,
+        .level_format = .upper,
+        .use_color = false,
+    };
+
+    const cfg = LogConfig{
+        .min_level = .debug,
+        .enable_colors = false,
+        .enable_file_logging = false,
+        .format_config = format_config,
+    };
+
+    var log = try Logger.init(allocator, cfg);
+    defer log.deinit();
+
+    try log.log(.info, "Formatted test message", .{}, null);
 }

--- a/tests/core_tests.zig
+++ b/tests/core_tests.zig
@@ -1,4 +1,3 @@
-// tests/core_tests.zig
 const std = @import("std");
 const testing = std.testing;
 const nexlog = @import("nexlog");
@@ -115,4 +114,26 @@ test "core: error conditions" {
     // Test with very long message
     const long_msg = "x" ** 1000;
     try logger.log(.info, "{s}", .{long_msg}, metadata);
+}
+
+// Test for formatter functionality
+test "formatter functionality test" {
+    const format_config = nexlog.FormatConfig{
+        .template = "[{timestamp}] [{level}] {message}",
+        .timestamp_format = .unix,
+        .level_format = .upper,
+        .use_color = false,
+    };
+
+    const config = nexlog.LogConfig{
+        .min_level = .debug,
+        .enable_colors = false,
+        .enable_file_logging = false,
+        .format_config = format_config,
+    };
+
+    var logger = try nexlog.Logger.init(testing.allocator, config);
+    defer logger.deinit();
+
+    try logger.log(.info, "Formatted test message", .{}, defaultMetadata());
 }


### PR DESCRIPTION
Refactor the public API and reimplement the `format.zig` functionality into the existing logger system.

* Modify `src/core/logger.zig` to use the formatter in `Logger.log` to format log messages.
* Re-export `FormatConfig` and `Formatter` from `utils/format.zig` in `src/nexlog.zig`.
* Add a test for the formatter functionality in `src/nexlog.zig`.
* Add a test for the formatter functionality in `tests/core_tests.zig`.

