### PR TITLE
Latest improvements

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        zig-version: ['0.13.0', 'master']
+        zig-version: ['0.14.0', 'master']
 
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -55,4 +55,4 @@ jobs:
 
     - name: Run examples
       if: success()
-      run: zig build examples
+      run: zig build all-examples

--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,8 @@ pub fn build(b: *std.Build) void {
         .{ .file = "examples/json_logging.zig", .name = "example_4" },
     };
 
+    const all_examples_step = b.step("all-examples", "Run all examples (for CI)");
+
     {
         for (examples) |example| {
             const exe = b.addExecutable(.{
@@ -93,6 +95,7 @@ pub fn build(b: *std.Build) void {
             run_step.dependOn(&run_cmd.step);
 
             test_step.dependOn(&run_cmd.step);
+            all_examples_step.dependOn(&run_cmd.step);
         }
     }
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,7 +6,8 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "nexlog",
+    .name = .nexlog,
+    .fingerprint = 0xc1b0e10c4c3f3cd,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.

--- a/examples/basic_usage.zig
+++ b/examples/basic_usage.zig
@@ -18,7 +18,7 @@ const OrderProcessor = struct {
         _ = self; // Tell Zig we're intentionally not using self for now
         return .{
             .timestamp = std.time.timestamp(),
-            .thread_id = 0, // In a real app, get actual thread ID
+            .thread_id = std.Thread.getCurrentId(), // In a real app, get actual thread ID
             .file = @src().file,
             .line = @src().line,
             .function = @src().fn_name,

--- a/examples/custom_handler.zig
+++ b/examples/custom_handler.zig
@@ -64,6 +64,17 @@ pub const CustomHandler = struct {
         try self.messages.append(formatted);
     }
 
+    // Add writeFormattedLog method to handle pre-formatted logs
+    pub fn writeFormattedLog(
+        self: *Self,
+        formatted_message: []const u8,
+    ) !void {
+        // For the custom handler, we just store the already-formatted message
+        // Make a copy since we'll own this memory
+        const message_copy = try self.allocator.dupe(u8, formatted_message);
+        try self.messages.append(message_copy);
+    }
+
     pub fn flush(self: *Self) !void {
         // Example: Print all stored messages
         for (self.messages.items) |msg| {
@@ -89,6 +100,7 @@ pub const CustomHandler = struct {
         return handlers.LogHandler.init(
             self,
             CustomHandler.log,
+            CustomHandler.writeFormattedLog,
             CustomHandler.flush,
             CustomHandler.deinit,
         );

--- a/examples/file_rotation.zig
+++ b/examples/file_rotation.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
         .setMinLevel(.debug)
         .enableColors(true)
         .setBufferSize(4096)
-    // Set small max file size to see rotation in action
+        // Set small max file size to see rotation in action
         .enableFileLogging(true, "logs/test.log")
         .setMaxFileSize(1024) // 1KB - small size to trigger rotations quickly
         .setMaxRotatedFiles(3) // Keep 3 backup files

--- a/src/core/logger.zig
+++ b/src/core/logger.zig
@@ -118,6 +118,8 @@ pub const Logger = struct {
         _ = self.log(.info, fmt, args, metadata) catch |log_error| {
             std.debug.print("Logger.info error: {}\n", .{log_error});
         };
+
+        try self.flush();
     }
 
     /// Logs a debug-level message.
@@ -125,6 +127,7 @@ pub const Logger = struct {
         _ = self.log(.debug, fmt, args, metadata) catch |log_error| {
             std.debug.print("Logger.debug error: {}\n", .{log_error});
         };
+        try self.flush();
     }
 
     /// Logs a warning-level message.
@@ -132,6 +135,7 @@ pub const Logger = struct {
         _ = self.log(.warn, fmt, args, metadata) catch |log_error| {
             std.debug.print("Logger.warn error: {}\n", .{log_error});
         };
+        try self.flush();
     }
 
     /// Logs an error-level message.
@@ -139,6 +143,7 @@ pub const Logger = struct {
         _ = self.log(.err, fmt, args, metadata) catch |log_error| {
             std.debug.print("Logger.error error: {}\n", .{log_error});
         };
+        try self.flush();
     }
 
     // Add a new handler

--- a/src/output/console.zig
+++ b/src/output/console.zig
@@ -8,7 +8,6 @@ pub const ConsoleConfig = struct {
     use_stderr: bool = true,
     buffer_size: usize = 4096,
 
-    // Add these options for metadata display
     show_source_location: bool = true,
     show_function: bool = false,
     show_thread_id: bool = false,

--- a/src/output/file.zig
+++ b/src/output/file.zig
@@ -109,7 +109,6 @@ pub const FileHandler = struct {
         }
     }
 
-    // Add this new method for formatted logs
     pub fn writeFormattedLog(self: *Self, formatted_message: []const u8) !void {
         self.mutex.lock();
         defer self.mutex.unlock();

--- a/src/output/handlers.zig
+++ b/src/output/handlers.zig
@@ -89,7 +89,7 @@ pub const LogHandler = struct {
 
         return .{
             .writeLogFn = GenericWriteLog,
-            .writeFormattedLogFn = GenericWriteFormattedLog, // Fixed: Added this missing field
+            .writeFormattedLogFn = GenericWriteFormattedLog,
             .flushFn = GenericFlush,
             .deinitFn = GenericDeinit,
             .ctx = pointer,

--- a/src/output/json.zig
+++ b/src/output/json.zig
@@ -119,7 +119,6 @@ pub const JsonHandler = struct {
         }
     }
 
-    // Add writeFormattedLog method for pre-formatted messages
     pub fn writeFormattedLog(
         self: *Self,
         formatted_message: []const u8,

--- a/src/utils/format.zig
+++ b/src/utils/format.zig
@@ -341,7 +341,11 @@ pub const Formatter = struct {
 
 /// Helper function to create a formatter with default configuration
 pub fn createDefaultFormatter(allocator: std.mem.Allocator) !*Formatter {
-    return Formatter.init(allocator, .{});
+    return Formatter.init(allocator, .{
+        .template = "[{timestamp}] [{color}{level}{reset}] [{file}:{line}] {message}",
+        .timestamp_format = .unix,
+        .use_color = true,
+    });
 }
 
 /// Example custom placeholder handler


### PR DESCRIPTION
This pull request includes several changes to the logging system, focusing on improving the handling of formatted log messages, updating the build process for examples, and enhancing the metadata displayed in console logs. The most important changes include the addition of a new method to handle pre-formatted logs, updates to the build script to simplify the example execution process, and enhancements to the console log handler to display more metadata.

Improvements to handling formatted log messages:

* [`src/core/logger.zig`](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bR23-L34): Added a new method to safely access the formatter and handle pre-formatted log messages. [[1]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bR23-L34) [[2]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bR79) [[3]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL91-R94) [[4]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL100-R156)
* [`src/output/handlers.zig`](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R14-R18): Updated the `LogHandler` struct to include a `writeFormattedLog` function pointer and implemented the corresponding method. [[1]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R14-R18) [[2]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R37-R40) [[3]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R66-R75) [[4]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R92) [[5]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R108-R111)

Updates to build process for examples:

* [`.github/workflows/blank.yml`](diffhunk://#diff-92f8d88918506bf156b28773f44c413b5bdc170468e8df422cf64bd9fcf8198dL58-R58): Changed the run command to `zig build all-examples` to build all examples at once.
* [`build.zig`](diffhunk://#diff-f87bb3596894756629bc39d595fb18d479dc4edf168d93a911cadcb060f10fccL61-R98): Refactored the build script to use a predefined list of examples instead of dynamically iterating through the examples directory.

Enhancements to console log handler:

* [`src/output/console.zig`](diffhunk://#diff-1635528dd24f898765fba1577073ea99bf006cb398af16c051617059593ab871L9-R13): Added configuration options to display additional metadata such as source location, function name, and thread ID in console logs. [[1]](diffhunk://#diff-1635528dd24f898765fba1577073ea99bf006cb398af16c051617059593ab871L9-R13) [[2]](diffhunk://#diff-1635528dd24f898765fba1577073ea99bf006cb398af16c051617059593ab871L47-R85) [[3]](diffhunk://#diff-1635528dd24f898765fba1577073ea99bf006cb398af16c051617059593ab871R99-R114)

Additional improvements:

* [`examples/basic_usage.zig`](diffhunk://#diff-6dea3057e6a13a0528be2db5c14ae9e2a180eeb8016caa2c7afe404eb49cbdcdL21-R21): Updated to use the actual thread ID in log entries.
* [`build.zig.zon`](diffhunk://#diff-12dc677c49af0bd162081512eac1adca6ec6040095aeaaa59cb9f931abccefc9L9-R10): Added a fingerprint to the package configuration.