### PR TITLE
Add handler type identification and separate formatters for console a…

### DIFF
--- a/examples/custom_handler.zig
+++ b/examples/custom_handler.zig
@@ -99,6 +99,7 @@ pub const CustomHandler = struct {
     pub fn toLogHandler(self: *Self) handlers.LogHandler {
         return handlers.LogHandler.init(
             self,
+            .custom,
             CustomHandler.log,
             CustomHandler.writeFormattedLog,
             CustomHandler.flush,

--- a/src/output/console.zig
+++ b/src/output/console.zig
@@ -95,6 +95,7 @@ pub const ConsoleHandler = struct {
     pub fn toLogHandler(self: *Self) handlers.LogHandler {
         return handlers.LogHandler.init(
             self,
+            .console,
             ConsoleHandler.log,
             ConsoleHandler.writeFormattedLog,
             ConsoleHandler.flush,

--- a/src/output/file.zig
+++ b/src/output/file.zig
@@ -231,6 +231,7 @@ pub const FileHandler = struct {
     pub fn toLogHandler(self: *Self) handlers.LogHandler {
         return handlers.LogHandler.init(
             self,
+            .file,
             FileHandler.writeLog,
             FileHandler.writeFormattedLog,
             FileHandler.flush,

--- a/src/output/handlers.zig
+++ b/src/output/handlers.zig
@@ -1,8 +1,19 @@
 const std = @import("std");
 const types = @import("../core/types.zig");
 
+/// Handler types for identification
+pub const HandlerType = enum {
+    console,
+    file,
+    network,
+    custom,
+};
+
 /// Interface that all log handlers must implement
 pub const LogHandler = struct {
+    /// Type of the handler
+    handler_type: HandlerType,
+
     /// Pointer to implementation of writeLog
     writeLogFn: *const fn (
         ctx: *anyopaque,
@@ -28,6 +39,7 @@ pub const LogHandler = struct {
     /// Create a LogHandler interface from a specific handler type
     pub fn init(
         pointer: anytype,
+        handler_type: HandlerType,
         comptime writeLogFnT: fn (
             ptr: @TypeOf(pointer),
             level: types.LogLevel,
@@ -88,6 +100,7 @@ pub const LogHandler = struct {
         }.implementation;
 
         return .{
+            .handler_type = handler_type,
             .writeLogFn = GenericWriteLog,
             .writeFormattedLogFn = GenericWriteFormattedLog,
             .flushFn = GenericFlush,

--- a/src/output/json.zig
+++ b/src/output/json.zig
@@ -167,6 +167,7 @@ pub const JsonHandler = struct {
     pub fn toLogHandler(self: *Self) handlers.LogHandler {
         return handlers.LogHandler.init(
             self,
+            .custom,
             JsonHandler.log,
             JsonHandler.writeFormattedLog,
             JsonHandler.flush,

--- a/src/output/network.zig
+++ b/src/output/network.zig
@@ -3,6 +3,7 @@ const types = @import("../core/types.zig");
 const errors = @import("../core/errors.zig");
 const buffer = @import("../utils/buffer.zig");
 const expect = std.testing.expect;
+const handlers = @import("handlers.zig");
 
 pub const NetworkEndpoint = struct {
     host: []const u8,
@@ -56,6 +57,18 @@ pub const NetworkHandler = struct {
         }
         self.circular_buffer.deinit();
         self.allocator.destroy(self);
+    }
+
+    /// Convert to generic LogHandler interface
+    pub fn toLogHandler(self: *Self) handlers.LogHandler {
+        return handlers.LogHandler.init(
+            self,
+            .network,
+            NetworkHandler.log,
+            NetworkHandler.writeFormattedLog,
+            NetworkHandler.flush,
+            NetworkHandler.deinit,
+        );
     }
 
     pub fn write(self: *Self, level: types.LogLevel, message: []const u8, metadata: ?types.LogMetadata) !void {


### PR DESCRIPTION
This pull request includes significant updates to the logging system, focusing on the introduction of multiple formatters and the addition of handler types. These changes enhance the flexibility and functionality of the logging system.

### Enhancements to Logging System:

* [`src/core/logger.zig`](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL18-R56): Introduced separate formatters for console and file outputs, enabling color formatting for console logs and standard formatting for file logs. Updated the `log` method to use the appropriate formatter based on the handler type. [[1]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL18-R56) [[2]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL68-R93) [[3]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL79) [[4]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL103-L122) [[5]](diffhunk://#diff-043a5534b0ab0ea23b3bf7e113aad9dda791168fa13ad1d8a06150322acdcc1bL131-R191)

### Addition of Handler Types:

* [`src/output/handlers.zig`](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R4-R16): Added `HandlerType` enum to identify different handler types (console, file, network, custom). Updated `LogHandler` struct to include a `handler_type` field and modified the `init` method to accept this new parameter. [[1]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R4-R16) [[2]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R42) [[3]](diffhunk://#diff-287e55c1728a15fdde569abf333722c86c4a0713e9348437aa1a8b2f7140e838R103)

### Updates to Specific Handlers:

* [`src/output/console.zig`](diffhunk://#diff-1635528dd24f898765fba1577073ea99bf006cb398af16c051617059593ab871R98): Modified `ConsoleHandler` to include the handler type `.console` when initializing a `LogHandler`.
* [`src/output/file.zig`](diffhunk://#diff-0d1ce6469094050c8e9caee82a3398290e755f8534ae1195916d1daf53cf9a48R234): Modified `FileHandler` to include the handler type `.file` when initializing a `LogHandler`.
* [`src/output/json.zig`](diffhunk://#diff-6d827d824ec67259eb6e9ccc67baeb874bc966f77ab516a2e4c011899de6ab1dR170): Modified `JsonHandler` to include the handler type `.custom` when initializing a `LogHandler`.
* [`src/output/network.zig`](diffhunk://#diff-f345eb6bb6e5cb93e501a50e5d726f8ba6d6e3213d496cffe64051ad026065aaR6): Modified `NetworkHandler` to include the handler type `.network` when initializing a `LogHandler`. [[1]](diffhunk://#diff-f345eb6bb6e5cb93e501a50e5d726f8ba6d6e3213d496cffe64051ad026065aaR6) [[2]](diffhunk://#diff-f345eb6bb6e5cb93e501a50e5d726f8ba6d6e3213d496cffe64051ad026065aaR62-R73)

### Custom Handler Update:

* [`examples/custom_handler.zig`](diffhunk://#diff-b4e224476e51f9d021aa45040e9a51d4fcdc744848a854fbdb0ba394ed3b5a14R102): Updated `CustomHandler` to include the handler type `.custom` when initializing a `LogHandler`.…nd file logging in Logger. Update LogHandler to include handler type. Modify existing handlers to utilize new structure.